### PR TITLE
Fix jinja2 XSS vulnerability by enabling HTML escaping

### DIFF
--- a/src/interprompt/jinja_template.py
+++ b/src/interprompt/jinja_template.py
@@ -19,7 +19,7 @@ class _JinjaEnvProvider:
 
     def get_env(self) -> jinja2.Environment:
         if self._env is None:
-            self._env = jinja2.Environment()
+            self._env = jinja2.Environment(autoescape=jinja2.select_autoescape(["html", "xml"]))
         return self._env
 
 


### PR DESCRIPTION
## Summary

- Fixed a security vulnerability identified by semgrep where jinja2.Environment() was being used without proper HTML escaping configuration
- The direct use of jinja2.Environment() without autoescape=True could lead to XSS vulnerabilities if user input is rendered through templates
- Configured jinja2.Environment with autoescape=jinja2.select_autoescape(['html', 'xml']) to ensure HTML and XML content is properly escaped

## Test plan

- [x] Ran existing test suite to ensure no regressions
- [x] Verified that HTML content is properly escaped (e.g., `<script>` tags are converted to `&lt;script&gt;`)
- [x] Code formatting and linting passes
- [x] Security vulnerability is resolved

🤖 Generated with [Claude Code](https://claude.ai/code)