### PR TITLE
Fix security vulnerability: Replace shell=True with shell=False in subprocess.run calls

### DIFF
--- a/src/solidlsp/language_servers/common.py
+++ b/src/solidlsp/language_servers/common.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shlex
 import subprocess
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -69,10 +70,13 @@ class RuntimeDependencyCollection:
 
     @staticmethod
     def _run_command(command: str, cwd: str) -> None:
+        # Parse command string into list of arguments to avoid shell injection
+        command_args = shlex.split(command)
+
         if PlatformUtils.get_platform_id().value.startswith("win"):
             subprocess.run(
-                command,
-                shell=True,
+                command_args,
+                shell=False,
                 check=True,
                 cwd=cwd,
                 stdout=subprocess.DEVNULL,
@@ -83,8 +87,8 @@ class RuntimeDependencyCollection:
 
             user = pwd.getpwuid(os.getuid()).pw_name
             subprocess.run(
-                command,
-                shell=True,
+                command_args,
+                shell=False,
                 check=True,
                 user=user,
                 cwd=cwd,


### PR DESCRIPTION
## Summary
- Fixed security vulnerability identified by semgrep in `src/solidlsp/language_servers/common.py`
- Replaced `shell=True` with `shell=False` in `subprocess.run` calls to prevent shell injection attacks
- Added proper command parsing using `shlex.split()` to maintain functionality with `shell=False`

## Changes Made
- Modified `_run_command` method in `RuntimeDependencyCollection` class
- Added `import shlex` to handle command string parsing
- Updated both Windows and Unix code paths consistently
- Added explanatory comment about security improvement

## Security Impact
- **Before**: Commands were executed through shell with `shell=True`, vulnerable to shell injection
- **After**: Commands are executed directly with `shell=False`, preventing shell injection attacks
- **Risk Mitigation**: Eliminates the possibility of malicious command injection through shell metacharacters

## Testing
- All existing tests continue to pass
- Integration tests for language servers exercise the RuntimeDependency functionality
- Code formatting and linting checks completed successfully

## Test plan
- [x] Verify existing tests still pass
- [x] Check code formatting with `uv run poe format`
- [x] Ensure no regression in language server functionality
- [x] Manual verification of security improvement

🤖 Generated with [Claude Code](https://claude.ai/code)