### PR TITLE
Fix file permissions security issue in Kotlin language server

### DIFF
--- a/src/solidlsp/language_servers/kotlin_language_server.py
+++ b/src/solidlsp/language_servers/kotlin_language_server.py
@@ -127,7 +127,7 @@ class KotlinLanguageServer(SolidLanguageServer):
             FileUtils.download_and_extract_archive(logger, java_dependency["url"], java_dir, java_dependency["archiveType"])
             # Make Java executable
             if not platform_id.value.startswith("win-"):
-                os.chmod(java_path, 0o755)
+                os.chmod(java_path, 0o744)
 
         assert os.path.exists(java_path), f"Java executable not found at {java_path}"
 


### PR DESCRIPTION
## Summary
- Fixed overly permissive file permissions in Kotlin language server
- Changed Java executable permissions from `0o755` to `0o744`
- Addresses semgrep security finding about widely permissive file permissions

## Changes Made
- Modified `src/solidlsp/language_servers/kotlin_language_server.py` line 130
- Changed `os.chmod(java_path, 0o755)` to `os.chmod(java_path, 0o744)`

## Security Impact
- Removes execute permissions for group and others
- Maintains necessary executable functionality for the owner
- Reduces potential security exposure while preserving functionality

## Test Plan
- [x] File compiles successfully
- [x] Code formatting checks pass
- [x] Code linting checks pass
- [x] No functional impact expected as Java executable still works for owner

🤖 Generated with [Claude Code](https://claude.ai/code)