### PR TITLE
Fix RegExp ReDoS vulnerability in dashboard tool name highlighting

### DIFF
--- a/src/serena/resources/dashboard/dashboard.js
+++ b/src/serena/resources/dashboard/dashboard.js
@@ -5,6 +5,11 @@ class LogMessage {
         this.$elem = $('<div>').addClass('log-' + logLevel).html(highlightedMessage + '\n');
     }
 
+    // Helper function to escape regex special characters
+    escapeRegExp(string) {
+        return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    }
+
     determineLogLevel(message) {
         if (message.startsWith('DEBUG')) {
             return 'debug';
@@ -21,8 +26,10 @@ class LogMessage {
 
     highlightToolNames(message, toolNames) {
         let highlightedMessage = message;
+        const self = this;
         toolNames.forEach(function(toolName) {
-            const regex = new RegExp('\\b' + toolName + '\\b', 'gi');
+            const escapedToolName = self.escapeRegExp(toolName);
+            const regex = new RegExp('\\b' + escapedToolName + '\\b', 'gi');
             highlightedMessage = highlightedMessage.replace(regex, '<span class="tool-name">' + toolName + '</span>');
         });
         return highlightedMessage;


### PR DESCRIPTION
## Summary

- Fix RegExp ReDoS vulnerability in dashboard.js line 25 identified by semgrep
- Add proper input sanitization by escaping regex special characters in tool names
- Prevent potential Regular Expression Denial-of-Service attacks

## Changes

- Added `escapeRegExp()` helper method to escape regex special characters
- Modified `highlightToolNames()` method to sanitize tool names before regex construction
- Maintained original functionality while preventing ReDoS vulnerability

## Test plan

- [ ] Verify dashboard still highlights tool names correctly in log messages
- [ ] Test with tool names containing regex special characters (e.g., `tool.name`, `tool*`, `tool+`)
- [ ] Confirm no performance issues or ReDoS vulnerability with malicious input
- [ ] Ensure existing functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)