### PR TITLE
Fix overly permissive file permissions in Kotlin language server

### DIFF
--- a/src/solidlsp/language_servers/kotlin_language_server.py
+++ b/src/solidlsp/language_servers/kotlin_language_server.py
@@ -127,7 +127,7 @@ class KotlinLanguageServer(SolidLanguageServer):
             FileUtils.download_and_extract_archive(logger, java_dependency["url"], java_dir, java_dependency["archiveType"])
             # Make Java executable
             if not platform_id.value.startswith("win-"):
-                os.chmod(java_path, 0o755)
+                os.chmod(java_path, 0o744)
 
         assert os.path.exists(java_path), f"Java executable not found at {java_path}"
 


### PR DESCRIPTION
## Summary
- Changed Java executable permissions from `0o755` to `0o744` in `kotlin_language_server.py`
- Addresses Semgrep rule finding about overly permissive file permissions
- Reduces access permissions for group and others while maintaining functionality for the owner

## Details
The Semgrep rule flagged the use of `0o755` permissions as overly permissive, noting that these permissions grant access to more people than necessary. The rule recommended `0o644` as a good default, but since this is an executable file, `0o644` would break functionality by removing execute permissions.

The fix uses `0o744` which:
- Maintains read, write, and execute permissions for the owner (necessary for Java executable)
- Reduces group and others to read-only access (following principle of least privilege)
- Preserves functionality while improving security posture

## Test plan
- [ ] Verify Kotlin language server still functions properly
- [ ] Confirm Java executable can still be executed by the owner
- [ ] Validate that Semgrep rule no longer flags this code
- [ ] Test on Linux/macOS platforms where this permission change applies

🤖 Generated with [Claude Code](https://claude.ai/code)