### PR TITLE
Fix overly permissive file permissions in Elixir tools

### DIFF
--- a/src/solidlsp/language_servers/elixir_tools/elixir_tools.py
+++ b/src/solidlsp/language_servers/elixir_tools/elixir_tools.py
@@ -135,7 +135,7 @@ class ElixirTools(SolidLanguageServer):
 
             # Make the binary executable on Unix-like systems
             if not platformId.value.startswith("win"):
-                os.chmod(binary_path, stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
+                os.chmod(binary_path, 0o700)
 
             # Create a symlink or copy with the expected name
             if binary_path != executable_path:


### PR DESCRIPTION
## Summary
- Fixed security issue in Elixir tools where downloaded Next LS binary had overly permissive file permissions (755)
- Changed permissions from `stat.S_IRWXU  < /dev/null |  stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH` to `0o700`
- This restricts access to owner only, following security best practices

## Test plan
- [ ] Verify the Elixir language server still works correctly
- [ ] Confirm the downloaded binary has the correct permissions (700)
- [ ] Run existing Elixir tests to ensure no functionality is broken

🤖 Generated with [Claude Code](https://claude.ai/code)