### PR TITLE
Fix Semgrep rule: Enable Jinja2 autoescape to prevent XSS

### DIFF
--- a/src/interprompt/jinja_template.py
+++ b/src/interprompt/jinja_template.py
@@ -19,7 +19,7 @@ class _JinjaEnvProvider:
 
     def get_env(self) -> jinja2.Environment:
         if self._env is None:
-            self._env = jinja2.Environment()
+            self._env = jinja2.Environment(autoescape=True)
         return self._env
 
 


### PR DESCRIPTION
## Summary
- Fixed Semgrep security rule by enabling Jinja2 autoescape to prevent XSS vulnerabilities
- Modified `src/interprompt/jinja_template.py` to include `autoescape=True` in Environment initialization
- Addresses direct Jinja2 usage that previously bypassed HTML escaping

## Changes
- **File**: `src/interprompt/jinja_template.py`
- **Line 22**: Added `autoescape=True` parameter to `jinja2.Environment()`

## Security Impact
This change prevents potential cross-site scripting (XSS) vulnerabilities by ensuring that all template output is automatically HTML-escaped unless explicitly marked as safe.

## Test Plan
- [ ] Verify existing functionality still works
- [ ] Run security scanning to confirm Semgrep rule passes
- [ ] Test template rendering with HTML content to ensure proper escaping

🤖 Generated with [Claude Code](https://claude.ai/code)